### PR TITLE
:sparkles: Add atan2 lut

### DIFF
--- a/wheel_autonomy/common/lookup_table/BUILD
+++ b/wheel_autonomy/common/lookup_table/BUILD
@@ -1,0 +1,20 @@
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+package(default_visibility = ["//visibility:public"])
+
+buildifier(
+    name = "buildifier",
+    lint_mode = "warn",
+    mode = "check",
+    verbose = True,
+)
+
+cc_library(
+    name = "lut",
+    srcs = [
+        "lut.cpp",
+    ],
+    hdrs = [
+        "lut.h",
+    ],
+)

--- a/wheel_autonomy/common/lookup_table/lut.cpp
+++ b/wheel_autonomy/common/lookup_table/lut.cpp
@@ -1,0 +1,98 @@
+#include "wheel_autonomy/common/lookup_table/lut.h"
+
+#include <array>
+#include <cmath>
+
+namespace wheel_autonomy {
+namespace common {
+namespace lut {
+
+namespace {
+// Set lookup table sample size. Larger value, more accurate, but more space
+// cost. When kLookupTableSampleSize is 20000, error less than 0.0057degree
+constexpr int kLookupTableSampleSize = 20000;
+static_assert(kLookupTableSampleSize % 2 == 0,
+              "kLookupTableSampleSize must be even");
+constexpr int kLookupTableSampleSize_2 = kLookupTableSampleSize / 2;
+
+// https://stackoverflow.com/questions/56207065/creating-a-lookup-table-at-compile-time
+#if __cplusplus >= 201703L
+// calculate lookup table at compile time, works with C++17
+constexpr std::array<float, kLookupTableSampleSize + 1>
+ConstructAtanLookupTable() {
+  std::array<float, kLookupTableSampleSize + 1> lut{0};
+  for (int i = 0; i <= kLookupTableSampleSize; ++i) {
+    float value = 2.0 / kLookupTableSampleSize * i - 1;
+    lut[i]      = std::atan(value);
+  }
+  return lut;
+}
+
+constexpr std::array<float, kLookupTableSampleSize + 1> kAtanLookupTable =
+    ConstructAtanLookupTable();
+#elif __cplusplus >= 201402L
+constexpr float GetAtanValueByLutIndex(std::size_t index) {
+  return std::atan(2.0 / kLookupTableSampleSize * index - 1);
+}
+
+template <std::size_t... I>
+constexpr auto LookupHelper(std::index_sequence<I...>) {
+  return std::array<float, sizeof...(I)>({GetAtanValueByLutIndex(I)...});
+}
+
+template <std::size_t N>
+constexpr auto ConstructLookupTable() {
+  return LookupHelper(std::make_index_sequence<N>());
+}
+
+// Calculate lookup table at compile time, works with C++14
+constexpr std::array<float, kLookupTableSampleSize + 1> kAtanLookupTable =
+    ConstructLookupTable<kLookupTableSampleSize + 1>();
+#else
+static_assert(false, "Not support compile calculate lut before c++14");
+#endif
+
+std::size_t GetLutIndex(float x) {
+  // use static_cast replace round for performance
+  return static_cast<std::size_t>(kLookupTableSampleSize_2 * (x + 1));
+}
+
+}  // namespace
+
+float Atan2LookUp(float y, float x) {
+  if (x == 0.0f) {
+    if (y < 0.0f) {
+      return -M_PI_2;
+    } else if (y > 0.0f) {
+      return M_PI_2;
+    } else {
+      return 0.0f;
+    }
+  }
+  if (y == 0.0f) {
+    if (x < 0.0f) {
+      return M_PI;
+    } else if (x > 0.0f) {
+      return 0.0f;
+    }
+  }
+
+  float ret;
+
+  if (std::abs(x) < std::abs(y)) {
+    ret = kAtanLookupTable[GetLutIndex(x / y)];
+    ret = static_cast<float>(x * y > 0 ? M_PI_2 - ret : -M_PI_2 - ret);
+  } else {
+    ret = kAtanLookupTable[GetLutIndex(y / x)];
+  }
+
+  if (x < 0) {
+    ret = static_cast<float>(y < 0 ? ret - M_PI : ret + M_PI);
+  }
+
+  return ret;
+}
+
+}  // namespace lut
+}  // namespace common
+}  // namespace wheel_autonomy

--- a/wheel_autonomy/common/lookup_table/lut.h
+++ b/wheel_autonomy/common/lookup_table/lut.h
@@ -1,0 +1,27 @@
+#pragma once
+
+/**
+ * @brief lookup table (LUT) is an array that replaces runtime computation with
+ * a simpler array indexing operation.
+ * Reference: https://en.wikipedia.org/wiki/Lookup_table
+ */
+
+namespace wheel_autonomy {
+namespace common {
+namespace lut {
+
+/**
+ * @brief Calculate atan2 by look up pre-calculated atan table.
+ *
+ * Interface: Same interface definition with std::atan2().
+ *
+ * Performance: 2x faster compare with std::atan2().
+ *
+ * Precision: angle error less than +/-0.0057degree. check result:
+ * https://colab.research.google.com/drive/1NBfbYWmgYCfvwGvAvaD70x6zJZMgLbat#scrollTo=sBPSjbXN2CsI
+ */
+float Atan2LookUp(float y, float x);
+
+}  // namespace lut
+}  // namespace common
+}  // namespace wheel_autonomy

--- a/wheel_autonomy/common/lookup_table/test/BUILD
+++ b/wheel_autonomy/common/lookup_table/test/BUILD
@@ -1,0 +1,23 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+
+package(default_visibility = ["//visibility:public"])
+
+buildifier(
+    name = "buildifier",
+    lint_mode = "warn",
+    mode = "check",
+    verbose = True,
+)
+
+cc_test(
+    name = "test_lut",
+    srcs = [
+        "test_lut.cpp",
+    ],
+    deps = [
+        "@gtest",
+        "@gtest//:gtest_main",
+        "//wheel_autonomy/common/lookup_table:lut"
+    ],
+)

--- a/wheel_autonomy/common/lookup_table/test/test_lut.cpp
+++ b/wheel_autonomy/common/lookup_table/test/test_lut.cpp
@@ -1,0 +1,81 @@
+#include "wheel_autonomy/common/lookup_table/lut.h"
+
+#include <gtest/gtest.h>
+#include <chrono>  // check performance
+#include <cmath>   // use std::ata2 as ground truth
+#include <random>  // generate random test data
+
+TEST(LUT, Atan2LookUp) {
+  // (y, x)
+  std::vector<std::pair<float, float>> test_case = {
+      {0.0f, 0.0f},    // x == 0 && y == 0
+      {-3.0f, -5.0f},  // -180 < degree < -135
+      {-5.0f, -5.0f},  // -135
+      {-5.0f, -3.0f},  // -135 < degree < -90
+      {-5.0f, 0.0f},   // -90
+      {-5.0f, 3.0f},   // -90 < degree < -45
+      {-5.0f, 5.0f},   // -45
+      {-3.0f, 5.0f},   // -45 < degree < 0
+      {0.0f, 5.0f},    // 0
+      {3.0f, 5.0f},    // 0 < degree < 45
+      {5.0f, 5.0f},    // 45
+      {5.0f, 3.0f},    // 45 < degree < 90
+      {5.0f, 0.0f},    // 90
+      {5.0f, -3.0f},   // 90 < degree < 135
+      {5.0f, -5.0f},   // 135
+      {3.0f, -5.0f},   // 135 < degree < 180
+      {0.0f, -5.0f},   // 180
+  };
+
+  for (std::size_t i = 0; i < test_case.size(); ++i) {
+    float y = test_case[i].first;
+    float x = test_case[i].second;
+    EXPECT_NEAR(std::atan2(y, x),
+                ::wheel_autonomy::common::lut::Atan2LookUp(y, x),
+                0.0001);  // 0.0001rad, 0.0057degree
+  }
+}
+
+TEST(LUT, Atan2LookUpPerformance) {
+  // generate random number in range [-200.0, 200.0]
+  const int sample_size = 70000;
+  std::vector<float> random_sample_x(sample_size);
+  std::vector<float> random_sample_y(sample_size);
+  for (std::size_t i = 0; i < sample_size; ++i) {
+    random_sample_x[i] =
+        static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * 400 - 200;
+    random_sample_y[i] =
+        static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * 400 - 200;
+  }
+
+  // evaluate precision
+  for (std::size_t i = 0; i < sample_size; ++i) {
+    float y = random_sample_y[i];
+    float x = random_sample_x[i];
+    EXPECT_NEAR(std::atan2(y, x),
+                ::wheel_autonomy::common::lut::Atan2LookUp(y, x),
+                0.0001);  // 0.0001rad, 0.0057degree
+  }
+
+  // evaluate performance
+  std::chrono::steady_clock::time_point t1, t2;
+  std::chrono::duration<double> time_span;
+  t1 = std::chrono::steady_clock::now();
+  for (std::size_t i = 0; i < sample_size; ++i) {
+    std::atan2(random_sample_y[i], random_sample_x[i]);
+  }
+  t2 = std::chrono::steady_clock::now();
+  time_span =
+      std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
+  std::cout << "std::atan2  cost: " << time_span.count();
+
+  t1 = std::chrono::steady_clock::now();
+  for (std::size_t i = 0; i < sample_size; ++i) {
+    ::wheel_autonomy::common::lut::Atan2LookUp(random_sample_y[i],
+                                               random_sample_x[i]);
+  }
+  t2 = std::chrono::steady_clock::now();
+  time_span =
+      std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1);
+  std::cout << "Atan2LookUp cost: " << time_span.count();
+}


### PR DESCRIPTION
`wheel_autonomy/common/lookup_table/lut.cpp:33:57: error: constexpr variable 'kAtanLookupTable' must be initialized by a constant expression
constexpr std::array<float, kLookupTableSampleSize + 1> kAtanLookupTable =
                                                        ^
wheel_autonomy/common/lookup_table/lut.cpp:19:10: note: non-constexpr function 'atan' cannot be used in a constant expression
  return std::atan(2.0 / kLookupTableSampleSize * index - 1);
         ^
wheel_autonomy/common/lookup_table/lut.cpp:24:43: note: in call to 'GetAtanValueByLutIndex(0)'
  return std::array<float, sizeof...(I)>({GetAtanValueByLutIndex(I)...});
                                          ^
wheel_autonomy/common/lookup_table/lut.cpp:29:10: note: in call to 'LookupHelper({})'
  return LookupHelper(std::make_index_sequence<N>());
         ^
wheel_autonomy/common/lookup_table/lut.cpp:34:5: note: in call to 'ConstructLookupTable()'
    ConstructLookupTable<kLookupTableSampleSize + 1>();
    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/math.h:317:15: note: declared here
extern double atan(double);
              ^
1 error generated.
`

Build failed, how to integrate c++17 compile env to Bazel instead of using local env?